### PR TITLE
Debug Test & Browser Compatibility

### DIFF
--- a/src/SleepRepository.js
+++ b/src/SleepRepository.js
@@ -1,7 +1,3 @@
-// Commented out if block in order for code to be compatible in browser. 
-// This currently breaks testing. 
-// Will refactor.
-
 class SleepRepository {
   constructor(data) {
     this.data = data;

--- a/src/SleepRepository.js
+++ b/src/SleepRepository.js
@@ -2,10 +2,6 @@
 // This currently breaks testing. 
 // Will refactor.
 
-// if (typeof module !== 'undefined') {
-//   var Sleep = require('../src/Sleep');
-// }
-
 class SleepRepository {
   constructor(data) {
     this.data = data;
@@ -27,14 +23,6 @@ class SleepRepository {
       return allUsers;
     }, {});
     this.organizedData = organizedData;
-  }
-  
-  generateSleepObjects() {
-    let arrayOfUsers = Object.values(this.organizedData)
-
-    this.users = arrayOfUsers.map((user, index) => {
-      return new Sleep((index + 1), user);
-    });
   }
 
   getTopSleepUsersBySleepQuality(date) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -14,7 +14,7 @@ let sleepAverage = document.querySelector('#sleep-average');
 
 window.addEventListener('load', function() {
   sleepRepository.getDataOrganizedByUser()
-  sleepRepository.generateSleepObjects()
+  generateSleepObjects(sleepRepository);
   userInfoUpdateHTML();
   updateHydrationWeekHTML("2019/06/22");
   updateHydrationDayHTML("2019/06/22");
@@ -64,4 +64,12 @@ function updateSleepWeekHTML(date) {
       'beforeend', `<p>sleep quality: ${currentSleepUser.getAveragePerDay("hoursSlept")}</p>
       <p>average hours: ${currentSleepUser.getAveragePerDay("sleepQuality")}</p>`
     );
+  }
+
+  function generateSleepObjects(sleepRepository) {
+    let arrayOfUsers = Object.values(sleepRepository.organizedData)
+
+    sleepRepository.users = arrayOfUsers.map((user, index) => {
+      return new Sleep((index + 1), user);
+    });
   }

--- a/test/Hydration-test.js
+++ b/test/Hydration-test.js
@@ -39,7 +39,8 @@ describe('Hydration', () => {
         "userID": 2,
         "date": "2019/06/14",
         "numOunces": 214
-      },{
+      },
+      {
         "userID": 1,
         "date": "2019/06/15",
         "numOunces": 115

--- a/test/SleepRepository-test.js
+++ b/test/SleepRepository-test.js
@@ -9,9 +9,10 @@ describe('SleepRepository', () => {
   let sleepUserData1;
   let sleepUserData2;
   let organizedTestData;
-  let sleepRepository;
   let sleepUser1;
   let sleepUser2;
+  let sleepRepository;
+  let arrayOfUsers;
   
   beforeEach(() => {
     sleepData = [
@@ -298,10 +299,17 @@ describe('SleepRepository', () => {
       ]
     }
 
-    sleepRepository = new SleepRepository(sleepData);
-
     sleepUser1 = new Sleep(1, sleepUserData1)
     sleepUser2 = new Sleep(2, sleepUserData2)
+    sleepRepository = new SleepRepository(sleepData);
+
+    sleepRepository.organizedData = organizedTestData;
+
+    arrayOfUsers = Object.values(sleepRepository.organizedData);
+
+    sleepRepository.users = arrayOfUsers.map((user, index) => {
+      return new Sleep((index + 1), user);
+    });
   });
  
   it('should be a function', () => {
@@ -326,29 +334,17 @@ describe('SleepRepository', () => {
     expect(sleepRepository.organizedData).to.deep.equal(organizedTestData);
   });
 
-  it('should be able to generate sleep objects for all users from organized data', () => { 
-    let organizedData = sleepRepository.getDataOrganizedByUser()
-    sleepRepository.generateSleepObjects(organizedData);
-    expect(sleepRepository.users).to.deep.equal([sleepUser1, sleepUser2]);
-  });
-
   it('should be able to return users with sleep quality above 3 based on a week', () => { 
-    let organizedData = sleepRepository.getDataOrganizedByUser()
-    sleepRepository.generateSleepObjects(organizedData);
     let topThreeUsers = sleepRepository.getTopSleepUsersBySleepQuality("2019/06/22");
     expect(topThreeUsers).to.deep.equal([sleepUser1]);
   });
 
   it('should be able to return the user with the most sleep for a given day', () => { 
-    let organizedData = sleepRepository.getDataOrganizedByUser()
-    sleepRepository.generateSleepObjects(organizedData);
     let result = sleepRepository.getTopSleepUsersByHoursSlept("2019/06/22")
     expect(result).to.deep.equal([sleepUser2.data[0]]);
   });
 
   it('should be able to return the user with the most sleep for a given day', () => { 
-    let organizedData = sleepRepository.getDataOrganizedByUser()
-    sleepRepository.generateSleepObjects(organizedData);
     let result = sleepRepository.getTopSleepUsersByHoursSlept("2019/06/18")
     expect(result).to.deep.equal([sleepUser1.data[3], sleepUser2.data[4]]);
   });


### PR DESCRIPTION
## Description
Fixed a bug that made testing fail when browser would succeed and vice-versa. This was due to the scope where Sleep was defined. Sleep instantiation still get assigned to sleepRepository.users, but the instantiation process of those objects happens within scripts.js

## Affected areas of application
Test functionality

## How Has This Been Tested?

- [x] Mocha / Chai
- [x] Chrome Browser & Chrome Inspector
- [x] Linter

## To-Dos
- [x] Setup
- [x] Iteration 1 
  - [x] UserRepository
  - [x] User
  - [x] Dashboard
- [x] Iteration 2
  - [x] Hydration
  - [x] Dashboard
- [x] Iteration 3
  - [x] Sleep
  - [x] Dashboard
- [ ] Iteration 4 
  - [ ] Activity
  - [ ] Dashboard
- [ ] Iteration 5
  - [ ] Trends
  - [ ] Dashboard
- [ ] Refactor & Cleanup
- [ ] README